### PR TITLE
chore: time trace file extension

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -62,7 +62,7 @@ func DefaultConfig() *Config {
 		},
 		Log: Log{
 			WriteToFile: true,
-			Path:        "ttrace.log",
+			Path:        "log.ttrace",
 		},
 		Name: "time_trace",
 	}

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -6,7 +6,7 @@ server:
 
 log:
   write_to_file: true
-  path: ttrace.log
+  path: log.ttrace        # Reminder, It is time trace file extention. 
 
 users:
 - name: root

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -6,7 +6,7 @@ server:
 
 log:
   write_to_file: true
-  path: log.ttrace        # Reminder, It is time trace file extention. 
+  path: log.ttrace
 
 users:
 - name: root

--- a/doc/config/config.md
+++ b/doc/config/config.md
@@ -37,7 +37,7 @@ How it looks in `config.yaml`:
 ```yml
 log:
   write_to_file: true
-  path: ttrace.log
+  path: log.ttrace
 ```
 
 #### users


### PR DESCRIPTION
## Description
It is change in the file extension. Where ttrace.log has been replaced with log.ttrace

## Related Issue

- Fixes #62

## Types of changes
- [x] Bug fix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (corrections, enhancements, or additions to documentation)
- [ ] Other (please describe): 

