### PR TITLE
perf: optimize access control method on user

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	_ "embed"
 	"os"
+	"slices"
 
 	tte "github.com/zurvan-lab/TimeTrace/utils/errors"
 	"gopkg.in/yaml.v2"
@@ -126,4 +127,12 @@ func (conf *Config) ToYAML() ([]byte, error) {
 	}
 
 	return buf.Bytes(), nil
+}
+
+func (u *User) HasAccess(c string) bool {
+	if u.Cmds[0] == "*" {
+		return true
+	}
+
+	return slices.Contains(u.Cmds, c)
 }

--- a/core/server/server.go
+++ b/core/server/server.go
@@ -124,8 +124,7 @@ func (s *Server) HandleConnection(conn net.Conn) {
 
 		query := parser.ParseQuery(string(buffer[:n]))
 
-		access := s.HaveAccess(*user, query.Command)
-		if access {
+		if user.HasAccess(query.Command) {
 			result := execute.Execute(query, s.db)
 
 			_, err = conn.Write([]byte(result))
@@ -173,22 +172,6 @@ func (s *Server) Authenticate(conn net.Conn) (*config.User, error) {
 	}
 
 	return user, nil
-}
-
-func (s *Server) HaveAccess(user config.User, command string) bool {
-	access := false
-
-	for _, c := range user.Cmds {
-		if c == command {
-			access = true
-		}
-	}
-
-	if user.Cmds[0] == "*" {
-		access = true
-	}
-
-	return access
 }
 
 func (s *Server) Stop() {


### PR DESCRIPTION
## Description

The access check function changed and now we can handle 30,000 element push in 1s. before it was around 3,000 element per second.

Also, it will keep its speed when we define access roles.
